### PR TITLE
Allow BER to be read as public data

### DIFF
--- a/include/framers/gr_hdlc_deframer_b.h
+++ b/include/framers/gr_hdlc_deframer_b.h
@@ -48,6 +48,9 @@ namespace gr {
        * creating new instances.
        */
       static sptr make(int dlci);
+
+      // Getters for public statistics
+      virtual float get_ber() = 0;
     };
 
   } // namespace framers

--- a/lib/gr_hdlc_deframer_b_impl.cc
+++ b/lib/gr_hdlc_deframer_b_impl.cc
@@ -109,6 +109,14 @@ namespace gr {
             total_packets++;
             
         }
+
+        /*
+         * Public Methods
+         */
+        float gr_hdlc_deframer_b_impl::get_ber()
+        {
+            return d_deframer.d_ber;
+        }
     } /* namespace framers */
 } /* namespace gr */
 

--- a/lib/gr_hdlc_deframer_b_impl.h
+++ b/lib/gr_hdlc_deframer_b_impl.h
@@ -35,6 +35,9 @@ namespace gr {
                              gr_vector_int &ninput_items,
                              gr_vector_const_void_star &input_items,
                              gr_vector_void_star &output_items);
+
+            // Getters for public statistics
+            float get_ber();
         };
         
     } // namespace framers

--- a/lib/hdlc_deframer.h
+++ b/lib/hdlc_deframer.h
@@ -29,6 +29,10 @@ public:
 
     // Debugging helper function for printing an HDLC packet
     static void print_packet(vector<unsigned char> packet);
+
+    // Public statistics
+    float d_ber;
+
 private:
     // CONSTANTS ------------------
     static const int           SUCCESS      = 1;
@@ -56,12 +60,14 @@ private:
     
     // Data statistics
     int            d_flag_cnt;
+    int            d_total_byte_cnt;
     int            d_good_frame_cnt;
     int            d_good_byte_cnt;
     int            d_good_dlci_cnt;
     int            d_unstuff_zero_cnt;
     // Error statistics
     int            d_crc_err_cnt;
+    int            d_err_byte_cnt;
     int            d_abort_cnt;
     int            d_seven_ones_cnt;
     int            d_non_align_cnt;


### PR DESCRIPTION
Compute the bit error rate (BER) internally and expose the result by
means of a publicly-accessible getter.