### PR TITLE
Support reading of frame error rate

### DIFF
--- a/include/framers/gr_hdlc_deframer_b.h
+++ b/include/framers/gr_hdlc_deframer_b.h
@@ -51,6 +51,8 @@ namespace gr {
 
       // Getters for public statistics
       virtual float get_ber() = 0;
+      virtual float get_fer() = 0;
+      virtual int get_n_frames() = 0;
     };
 
   } // namespace framers

--- a/lib/gr_hdlc_deframer_b_impl.cc
+++ b/lib/gr_hdlc_deframer_b_impl.cc
@@ -113,9 +113,23 @@ namespace gr {
         /*
          * Public Methods
          */
+
+        /* Bit error rate */
         float gr_hdlc_deframer_b_impl::get_ber()
         {
             return d_deframer.d_ber;
+        }
+
+        /* Frame error rate */
+        float gr_hdlc_deframer_b_impl::get_fer()
+        {
+            return d_deframer.d_fer;
+        }
+
+        /* Total number of frames so far */
+        int gr_hdlc_deframer_b_impl::get_n_frames()
+        {
+            return d_deframer.d_n_frames;
         }
     } /* namespace framers */
 } /* namespace gr */

--- a/lib/gr_hdlc_deframer_b_impl.h
+++ b/lib/gr_hdlc_deframer_b_impl.h
@@ -38,6 +38,8 @@ namespace gr {
 
             // Getters for public statistics
             float get_ber();
+            float get_fer();
+            int get_n_frames();
         };
         
     } // namespace framers

--- a/lib/hdlc_deframer.cc
+++ b/lib/hdlc_deframer.cc
@@ -39,7 +39,10 @@ hdlc_deframer::hdlc_deframer(int dlci) :
     d_non_align_cnt(0),
     d_giant_cnt(0),
     d_runt_cnt(0),
-    d_unstuff_zero_cnt(0)
+    d_unstuff_zero_cnt(0),
+    d_ber(0.0),
+    d_fer(0.0),
+    d_n_frames(0)
 {
 
 }
@@ -299,8 +302,10 @@ hdlc_deframer::hdlc_state_machine(const unsigned char next_bit)
                             }
                         }
 
-                        // Update BER
-                        d_ber = (float) d_err_byte_cnt / d_total_byte_cnt;
+                        // Update statistics: BER, BER and number of frames
+                        d_n_frames = d_crc_err_cnt + d_good_frame_cnt;
+                        d_fer      = (float) d_crc_err_cnt / d_n_frames;
+                        d_ber      = (float) d_err_byte_cnt / d_total_byte_cnt;
                     }
                 }
                 // Hunt for next flag or frame

--- a/lib/hdlc_deframer.h
+++ b/lib/hdlc_deframer.h
@@ -32,6 +32,8 @@ public:
 
     // Public statistics
     float d_ber;
+    float d_fer;
+    int d_n_frames;
 
 private:
     // CONSTANTS ------------------


### PR DESCRIPTION
Compute the HDLC frame error (drop) rate based on CRC failures and make this
statistic public through getter callbacks. Additionally, add getter for the
total number of frames CRC-checked so far. Using the total number of frames and
the frame error rate, one can compute the precise number of frames that were
dropped. These metrics are intended to complement the information provided by
the bit error rate.